### PR TITLE
build: soong: use jemalloc by default and allow opt-in to scudo (2/3)

### DIFF
--- a/android/config.go
+++ b/android/config.go
@@ -965,7 +965,7 @@ func (c *config) EnableCFI() bool {
 }
 
 func (c *config) DisableScudo() bool {
-	return Bool(c.productVariables.DisableScudo)
+	return !Bool(c.productVariables.Malloc_use_scudo)
 }
 
 func (c *config) Android64() bool {

--- a/android/variable.go
+++ b/android/variable.go
@@ -64,13 +64,20 @@ type variableProperties struct {
 			Enabled *bool `android:"arch_variant"`
 		} `android:"arch_variant"`
 
-		Malloc_not_svelte struct {
+		Malloc_use_scudo struct {
 			Cflags              []string `android:"arch_variant"`
 			Shared_libs         []string `android:"arch_variant"`
 			Whole_static_libs   []string `android:"arch_variant"`
 			Exclude_static_libs []string `android:"arch_variant"`
 			Srcs                []string `android:"arch_variant"`
 			Header_libs         []string `android:"arch_variant"`
+		} `android:"arch_variant"`
+
+		Malloc_not_svelte struct {
+			Cflags              []string `android:"arch_variant"`
+			Shared_libs         []string `android:"arch_variant"`
+			Whole_static_libs   []string `android:"arch_variant"`
+			Exclude_static_libs []string `android:"arch_variant"`
 		} `android:"arch_variant"`
 
 		Malloc_zero_contents struct {
@@ -259,6 +266,7 @@ type productVariables struct {
 	Unbundled_build_image        *bool    `json:",omitempty"`
 	Always_use_prebuilt_sdks     *bool    `json:",omitempty"`
 	Skip_boot_jars_check         *bool    `json:",omitempty"`
+	Malloc_use_scudo             *bool    `json:",omitempty"`
 	Malloc_not_svelte            *bool    `json:",omitempty"`
 	Malloc_zero_contents         *bool    `json:",omitempty"`
 	Malloc_pattern_fill_contents *bool    `json:",omitempty"`
@@ -291,8 +299,6 @@ type productVariables struct {
 	EnableCFI       *bool    `json:",omitempty"`
 	CFIExcludePaths []string `json:",omitempty"`
 	CFIIncludePaths []string `json:",omitempty"`
-
-	DisableScudo *bool `json:",omitempty"`
 
 	MemtagHeapExcludePaths      []string `json:",omitempty"`
 	MemtagHeapAsyncIncludePaths []string `json:",omitempty"`
@@ -493,6 +499,7 @@ func (v *productVariables) SetDefaultConfig() {
 		AAPTCharacteristics: stringPtr("nosdcard"),
 		AAPTPrebuiltDPI:     []string{"xhdpi", "xxhdpi"},
 
+		Malloc_use_scudo:             boolPtr(false),
 		Malloc_not_svelte:            boolPtr(true),
 		Malloc_zero_contents:         boolPtr(true),
 		Malloc_pattern_fill_contents: boolPtr(false),


### PR DESCRIPTION
Also, clean up broken DisableScudo/PRODUCT_DISABLE_SCUDO.

After these changes, malloc_not_svelte is only used to override cflags in external/jemalloc_new. Change accordingly.

Detailed reason for switching to jemalloc by default is written in the bionic commit.

Change-Id: Id5afcf064a5db6011676dc7141c71fd5bb0007cb